### PR TITLE
Add default image support to gravatars

### DIFF
--- a/code/extensions/CloudinaryTemplateProvider.php
+++ b/code/extensions/CloudinaryTemplateProvider.php
@@ -19,11 +19,13 @@ class CloudinaryTemplateProvider implements TemplateGlobalProvider {
         return Cloudinary::cloudinary_url($profile, $options);
     }
 
-    public static function CloudinaryGravatar($email, $width = 100) {
+    public static function CloudinaryGravatar($email, $width = 100, $default = "mm") {
         $options["type"] = "gravatar";
         $options["format"] = "jpg";
         $options["secure"] = true;
         $options["width"] = $width;
+        // See https://en.gravatar.com/site/implement/images/ for available options
+        $options["default_image"] = $default;
         $emailHash = md5(strtolower(trim($email)));
         return Cloudinary::cloudinary_url($emailHash, $options);
     }


### PR DESCRIPTION
<img width="228" alt="screen shot 2016-06-29 at 13 01 27" src="https://cloud.githubusercontent.com/assets/123386/16451233/ac1ac612-3df9-11e6-8eaa-7fc343e56b93.png">

Can be override in templates:

```
$CloudinaryGravatar("example@example.com", 100, "identicon")
```

@adammade 