### PR TITLE
Fix for .Image() call where gravity was showing as 1 in URL

### DIFF
--- a/code/models/CloudinaryFile.php
+++ b/code/models/CloudinaryFile.php
@@ -70,7 +70,7 @@ class CloudinaryFile extends DataObject
             'quality' =>  $quality,
             'width' => $width,
             'height' => $height,
-            'gravity' => $gravity || $this->Gravity
+            'gravity' => $gravity ?: $this->Gravity
         );
 
         if($crop){


### PR DESCRIPTION
This was because the value would be true which translates
  to 1

Updated to use Ternary