### PR TITLE
Fix for Cloudinary Upload button not always working

### DIFF
--- a/javascript/CloudinaryAdmin.js
+++ b/javascript/CloudinaryAdmin.js
@@ -61,10 +61,11 @@
     $('#cloudinary-cms-content').entwine({
 
         onmatch : function() {
-            if(!window.cloudinary){
+            var scriptSrc = '//widget.cloudinary.com/global/all.js';
+            if($('script[src="' + scriptSrc + '"]')){
                 var script = document.createElement('script');
                 script.type = 'text/javascript';
-                script.src = '//widget.cloudinary.com/global/all.js';
+                script.src = scriptSrc;
                 document.body.appendChild(script);
             }
         }


### PR DESCRIPTION
The issue is that the jquery.cloudinary module sets
  window.cloudinary which is what we where checking for
  the all.js file.

Improved checking logic to determine if all.js script
  tag has been added and seems to work well

example video (http://quick.as/zpBJHXyJ3)