### PR TITLE
Add custom CloudinaryFileField_holder

### DIFF
--- a/templates/CloudinaryFileField_holder.ss
+++ b/templates/CloudinaryFileField_holder.ss
@@ -1,0 +1,8 @@
+<div id="$HolderID" class="field<% if $extraClass %> $extraClass<% end_if %>">
+	<% if $Title %><label class="left" for="$ID">$Title</label><% end_if %>
+	<div class="middleColumn">
+		$Field
+	</div>
+	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
+	<% if $Description %><span class="description">$Description</span><% end_if %>
+</div>

--- a/templates/Includes/CloudinaryFileField.ss
+++ b/templates/Includes/CloudinaryFileField.ss
@@ -3,6 +3,7 @@
         {$URLField}
         <a href="#" class="cloudinary__browser _js-cloudinary-browser ss-ui-action-constructive ss-ui-button cloudinary-type-{$FileType} ui-button ui-widget ui-state-default ui-corner-all new new-link ui-button-text-icon-primary">Choose {$FileType}</a>
     </div>
+    <% if $RightTitle %><label class="right" for="$ID">$RightTitle</label><% end_if %>
     <div class="cloudinary__fields <% if $isPopuplated %>cloudinary__fields--expanded<% end_if %>">
         <% loop $DataFields %>
             <div class="cloudinary__fields__field <% if $CommonField %>_js-common<% else_if $HiddenFileField %>_js-hidden-data<% else %>_js-image-data<% end_if %>">


### PR DESCRIPTION
This removes the RightTitle and moves it to the field this is so a Right Title appears under the URL instead of under all the metadata fields

![image](https://cloud.githubusercontent.com/assets/1453382/18468770/4d5758f4-799d-11e6-833e-028d711526a5.png)
