### PR TITLE
Windows10:Chrome53 has an AM/PM on time fields

### DIFF
--- a/code/Fields/CloudinaryAudioField.php
+++ b/code/Fields/CloudinaryAudioField.php
@@ -14,7 +14,7 @@ class CloudinaryAudioField extends CloudinaryFileField
         $lengthField
             ->setName($name . "[" . $lengthField->getName() . "]")
             ->addExtraClass('_js-attribute')
-            // ->setInterval(2)
+            ->addExtraClass('cloudinary__no-am-pm')
             ->setConfig('timeformat', 'HH:mm:ss');
         $this->children->push($lengthField);
 

--- a/css/CloudinaryFileField.css
+++ b/css/CloudinaryFileField.css
@@ -26,7 +26,9 @@
 .cloudinary__fields__field .field .middleColumn {
     margin: 0;
 }
-
+.cloudinary__no-am-pm::-webkit-datetime-edit-ampm-field {
+   display: none;
+ }
 .cloudinary__browser__window {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
This hides the AM/PM on the input field
![image](https://cloud.githubusercontent.com/assets/1453382/18710743/aa2e88a6-7ffe-11e6-90b9-e84b43a2c032.png)
![image](https://cloud.githubusercontent.com/assets/1453382/18710763/c67eca84-7ffe-11e6-9a76-476df038166a.png)
