### PR TITLE
Fix for different crop types that break with gravity

### DIFF
--- a/code/models/CloudinaryImage.php
+++ b/code/models/CloudinaryImage.php
@@ -73,6 +73,10 @@ class CloudinaryImage extends CloudinaryFile
         if ($gravity) {
             $options['gravity'] = $gravity;
         }
+        // These crops don't support gravity, Cloudinary returns a 400 if passed
+        if (in_array($crop, array('fit', 'limit', 'mfit', 'pad', 'lpad'))) {
+            unset($options['gravity']);
+        }
 
         $cloudinaryID = CloudinaryUtils::public_id($this->URL);
         $fileName = $this->Format ? $cloudinaryID. '.'. $this->Format : $cloudinaryID;


### PR DESCRIPTION
Some crop types break if you pass in a Gravity
This would be due to it not being applicable

e.g.
https://res.cloudinary.com/mhrth/image/upload/c_fit,f_auto,g_auto,h_535,q_auto,w_600/ev-Skydiggers-cutout_zxaean.png
https://res.cloudinary.com/mhrth/image/upload/c_fit,f_auto,h_535,q_auto,w_600/ev-Skydiggers-cutout_zxaean.png
