### PR TITLE
FD-18601: Fix for non-images (e.g. PDFs) that are being stored as ima…

### DIFF
--- a/src/Model/Image.php
+++ b/src/Model/Image.php
@@ -16,6 +16,16 @@ class Image extends File
     private static $non_gravity_crops = ['fit', 'limit', 'mfit', 'pad', 'lpad'];
 
     /**
+     * @var array
+     * @config
+     */
+    private static $valid_image_formats = [
+        'jpg',
+        'gif',
+        'png',
+    ];
+
+    /**
      * These are basically defaults
      * @var array
      */
@@ -343,12 +353,20 @@ class Image extends File
 
         // These crops don't support gravity, Cloudinary returns a 400 if passed
         $nonGravityCrops = static::config()->get('non_gravity_crops');
+        $isImage = in_array($this->Format, static::config()->get('valid_image_formats'));
 
         // Loop through all and apply the generic stuff
         foreach ($transformations as &$transformation) {
             // Remove gravity if specific crop is applied
             if (array_key_exists('crop', $transformation) && in_array($transformation['crop'], $nonGravityCrops)) {
                 unset($transformation['gravity']);
+            }
+            if (
+                !$isImage &&
+                (!array_key_exists('width', $transformation) || empty($transformation['width'])) &&
+                (!array_key_exists('height', $transformation) || empty($transformation['height']))
+            ) {
+                unset($transformation['fetch_format']);
             }
         }
 


### PR DESCRIPTION
…ges (will need to work on uploader to resolve this)

https://mademedia.freshdesk.com/a/tickets/18601

If there are no width or height parameters then need to remove the `fetch_format`
  this means that it will be returned using the original format

Will look at doing check of the filename to only do this if its a PDF