### PR TITLE
Replace the silverstripe regular file asset with cloudinary & allow r…

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -32,6 +32,9 @@ SilverStripe\Core\Injector\Injector:
   Image:
     class: MadeHQ\Cloudinary\Model\Image
 
+  SilverStripe\Assets\File:
+    class: MadeHQ\Cloudinary\Model\File
+
   File:
     class: MadeHQ\Cloudinary\Model\File
 


### PR DESCRIPTION
https://mademedia.freshdesk.com/a/tickets/62918

LAO had a bug where file uploads were attempting to be uploaded to cloudinary, but failing because they weren't images.

This fixes that, and also adds a little bit of logic so that uploading files with the same name does not cause errors