### PR TITLE
Migration amends

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -8,6 +8,7 @@ use Cloudinary\Utils;
 use MadeHQ\Cloudinary\UserForms\Controllers\FormAdmin;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
+use SilverStripe\View\Parsers\ShortcodeParser;
 
 // Remove the Asset Admin link
 CMSMenu::remove_menu_class(AssetAdmin::class);
@@ -62,3 +63,7 @@ call_user_func(function () {
             ->getResource('client/src/js/TinyMCE_ssmedia.js'),
     ]);
 });
+
+// Remove SS Asset Admin Shortcode parser
+ShortcodeParser::get('regenerator')
+    ->unregister('image');

--- a/_config.php
+++ b/_config.php
@@ -8,7 +8,6 @@ use Cloudinary\Utils;
 use MadeHQ\Cloudinary\UserForms\Controllers\FormAdmin;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
-use SilverStripe\View\Parsers\ShortcodeParser;
 
 // Remove the Asset Admin link
 CMSMenu::remove_menu_class(AssetAdmin::class);
@@ -63,7 +62,3 @@ call_user_func(function () {
             ->getResource('client/src/js/TinyMCE_ssmedia.js'),
     ]);
 });
-
-// Remove SS Asset Admin Shortcode parser
-ShortcodeParser::get('regenerator')
-    ->unregister('image');

--- a/src/Controllers/API.php
+++ b/src/Controllers/API.php
@@ -166,8 +166,8 @@ class API extends RequestHandler
             $return['foreground_colour'] = null;
             $return['background_colour'] = null;
             $return['transformations'] = null;
-            $return['width'] = $data['width'];
-            $return['height'] = $data['height'];
+            $return['width'] = @$data['width'];
+            $return['height'] = @$data['height'];
         } else {
             $return['actual_type'] = 'raw';
         }

--- a/src/Tasks/MigrationTaskStep2.php
+++ b/src/Tasks/MigrationTaskStep2.php
@@ -263,7 +263,7 @@ SQL;
                 '{LinkTable}' => $schema->tableName(ImageLink::class),
                 '{FileTable}' => $schema->tableName(File::class),
                 '{VersionSuffix}' => $tableSuffix,
-                '{RootRelationName}' => $do->ClassName,
+                '{RootRelationName}' => $tableName,
                 '{ID}' => $do->ID,
             ]
         ));


### PR DESCRIPTION
Fixes an SQL issue when inheriting relationship
Updates queries to use `INSERT ... ON DUPLICATE UPDATE`
Adds calls to `::augmentMigrationData()` functionality to customise the data before it is written