### PR TITLE
Remove the `username` requirement

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -17,7 +17,7 @@ CMSMenu::remove_menu_class(FormAdmin::class);
 $settings = Config::inst()->get('MadeHQ\\Cloudinary');
 
 // We absolutely need these items
-$options = ['cloud_name', 'api_key', 'api_secret', 'username'];
+$options = ['cloud_name', 'api_key', 'api_secret'];
 
 $valid = true;
 


### PR DESCRIPTION
The `username` shouldn't be a *requirement* as it should be possible for different users to login (still limited to the one account at the moment)