### PR TITLE
Enable setMultiple method under basefield

### DIFF
--- a/src/Forms/BaseField.php
+++ b/src/Forms/BaseField.php
@@ -286,4 +286,12 @@ abstract class BaseField extends TextareaField
 
         return $options;
     }
+
+    
+    public function setMultiple(bool $isMultiple): BaseField
+    {
+        $this->isMultiple = $isMultiple;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Enable setMultiple method under basefield.

Usage: 

```
        $fields->addFieldToTab('Root.Main', ImageField::create('ImageGallery')->setMultiple(true));
        $fields->addFieldToTab('Root.Main', MediaField::create('VideoGallery')->setMultiple(true));
        $fields->addFieldToTab('Root.Main', FileField::create('Downloads')->setMultiple(true));
```

Based on this error which i raised:
https://github.com/MadeHQ/silverstripe-cloudinary/issues/185